### PR TITLE
test correction on multitemp_mask function

### DIFF
--- a/yatsm/masking.py
+++ b/yatsm/masking.py
@@ -47,8 +47,8 @@ def multitemp_mask(x, Y, n_year, crit=400,
     green_RLM = rlm.RLM(M=rlm.bisquare, maxiter=maxiter).fit(X, green)
     swir1_RLM = rlm.RLM(M=rlm.bisquare, maxiter=maxiter).fit(X, swir1)
 
-    mask = ((green - green_RLM.predict(X) < crit) *
-            (swir1 - swir1_RLM.predict(X) > -crit))
+    mask = ((green - green_RLM.predict(X) > crit) +
+            (swir1 - swir1_RLM.predict(X) < -crit))
 
     return mask
 


### PR DESCRIPTION
There was two mistake on multitemp_mask function where undetected clouds, cloud shadows, snow are masked at the end of the initalization period. 


1. test on bands : inversion of > and <
test should mask pixels where` green - green_rlm > crit` (current: `< crit` ) and `swir1 - swir1_rml < -crit` (current: `> - crit`)

2. test should mask pixel if green test **OR** (`+`) swir1 test is validated (current is **AND** (`*`))

