### PR TITLE
Remove index attribute

### DIFF
--- a/yatsm/io/backends/_gdal.py
+++ b/yatsm/io/backends/_gdal.py
@@ -169,7 +169,7 @@ class GDALTimeSeries(object):
             with rasterio.Env():  # TODO: pass options
                 null = rows.index[rows[KEY].isnull()]
 
-                self.df.loc[null.index, KEY] = [
+                self.df.loc[null, KEY] = [
                     rasterio.open(f, 'r') for f in
                     self.df.loc[null, 'filename']
                 ]


### PR DESCRIPTION
`null` doesn't seem to have an `index` attribute at this point,
and I think just indexing by `null` works as expected