### PR TITLE
Convert cfg -> reader

### DIFF
--- a/yatsm/io/_api.py
+++ b/yatsm/io/_api.py
@@ -102,7 +102,7 @@ def read_and_preprocess(config, readers, window, out=None):
     for name, cfg in config.items():
         reader = readers[name]
         arr = reader.read_dataarray(window=window,
-                                    band_names=cfg['band_names'],
+                                    band_names=reader.band_names,
                                     out=out)
 
         if cfg['mask_band'] and cfg['mask_values']:


### PR DESCRIPTION
This morning's bugfixes coming your way.

`cfg` here is the config['data']['datasets'][$name]
which doesn't have a `band_names` key. The reader does, however.

There are other ways to get the band names associated with
the reader from `cfg` rather than `reader`, but I'm fairly
confident that `reader.band_names` is always what we want
here