### PR TITLE
Fix indexing of the dataset

### DIFF
--- a/yatsm/io/_xarray.py
+++ b/yatsm/io/_xarray.py
@@ -70,7 +70,7 @@ def merge_data(data, merge_attrs=True):
         xr.Dataset: Merged xr.DataArray objects in one xr.Dataset
     """
     # TODO: (re)projections
-    ds_crs = [CRS.from_string(ds.attrs['crs_wkt']) for ds in data]
+    ds_crs = [CRS.from_string(data[ds].attrs['crs_wkt']) for ds in data]
     if not share_crs(*ds_crs):
         raise TODO('Cannot merge data with different CRS')
 


### PR DESCRIPTION
`ds in data` returns the name of the dataset (i.e. 'Landsat')
which is a string and doesn't have an `attrs` attribute. This
causes an error. It's an easy fix though to index into the `data`
by this string.