### PR TITLE
Move CONFIG CLI option to yatsm main cmd

### DIFF
--- a/yatsm/cli/batch.py
+++ b/yatsm/cli/batch.py
@@ -15,7 +15,6 @@ logger = logging.getLogger('yatsm')
 
 
 @click.command(short_help='Run a YATSM pipeline on a dataset in batch mode')
-@options.arg_config
 @options.arg_job_number
 @options.arg_total_jobs
 @options.opt_executor
@@ -23,7 +22,7 @@ logger = logging.getLogger('yatsm')
               help='Override dataset block size when reading')
 @options.opt_force_overwrite
 @click.pass_context
-def batch(ctx, config, job_number, total_jobs, executor, block_size,
+def batch(ctx, job_number, total_jobs, executor, block_size,
           force_overwrite):
     """ Run a YATSM pipeline on a dataset in batch mode
 
@@ -36,6 +35,7 @@ def batch(ctx, config, job_number, total_jobs, executor, block_size,
     TODO: Users may override the size of the subsets using command line
           options.
     """
+    config = options.fetch_config(ctx)
     # Imports inside CLI for speed
     from yatsm.io.utils import block_windows
     from yatsm.utils import distribute_jobs

--- a/yatsm/cli/changemap.py
+++ b/yatsm/cli/changemap.py
@@ -28,7 +28,6 @@ def changemap(ctx):
 
 
 @changemap.command(short_help="Date of first change")
-@options.arg_config
 @options.arg_start_date
 @options.arg_end_date
 @options.arg_output
@@ -37,12 +36,13 @@ def changemap(ctx):
 @options.mapping_decorations
 @options.opt_date_format
 @options.opt_map_date_format
-def first(ctx, config, start_date, end_date, output,
+def first(ctx, start_date, end_date, output,
           table, bounds,
           driver, nodata, creation_options, force_overwrite,
           date_format, map_date_format):
     """ Date of first change
     """
+    config = options.fetch_config(ctx)
     # TODO: make this an input...
     # TODO: mapping between
     #           * output band # and total # bands

--- a/yatsm/cli/main.py
+++ b/yatsm/cli/main.py
@@ -58,12 +58,14 @@ from ._logger import config_logging
 # YATSM CLI group
 _context = dict(
     token_normalize_func=lambda x: x.lower(),
-    help_option_names=['--help', '-h']
+    help_option_names=['--help', '-h'],
+    auto_envvar_prefix='YATSM'
 )
 
 @click_plugins.with_plugins(ep for ep in
                             iter_entry_points('yatsm.cli'))
-@click.group(help='YATSM command line interface', context_settings=_context)
+@click.group(context_settings=_context)
+@options.opt_config
 @click.version_option(yatsm.__version__)
 @click.option('--num_threads', default=1, type=int,
               show_default=True, callback=options.valid_int_gt_zero,
@@ -71,10 +73,21 @@ _context = dict(
 @cligj.verbose_opt
 @cligj.quiet_opt
 @click.pass_context
-def cli(ctx, num_threads, verbose, quiet):
+def cli(ctx, config, num_threads, verbose, quiet):
+    """ YATSM Applications
+
+    Note:
+    Be sure to specify the configuration file you want to work with as
+    ``yatsm -C CONFIG_FILE [COMMAND]``. You might also consider defining
+    the path to the configuration file as an environment variable,
+    ``YATSM_CONFIG``. Defining this variable allows YATSM to retrieve
+    the location of your configuration file without the need to explicitly
+    include the ``-C`` when you write ``yatsm [COMMAND...]`` commands,
+    simplifying interactive use.
+    """
     verbosity = verbose - quiet
     level = max(10, 30 - 10 * verbosity)
     logger = config_logging(level, config=None)  # TODO: dictConfig file arg
-    ctx.obj = {}
+    ctx.obj = ctx.obj or {}
     ctx.obj['verbosity'] = verbosity
-
+    ctx.obj['config'] = config


### PR DESCRIPTION
Config is used for most commands, so makes sense to put in main YATSM command. Also allows `config` file to come from environment variable (YATSM_CONFIG) (see click docs [here](http://click.pocoo.org/5/options/#dynamic-defaults-for-prompts) and [here](http://click.pocoo.org/5/options/#values-from-environment-variables) for explanation). New CLI looks like

``` bash
> yatsm --help
Usage: yatsm [OPTIONS] COMMAND [ARGS]...

  YATSM Applications

  Note: Be sure to specify the configuration file you want to work with as
  ``yatsm -C CONFIG_FILE [COMMAND]``. You might also consider defining the
  path to the configuration file as an environment variable,
  ``YATSM_CONFIG``. Defining this variable allows YATSM to retrieve the
  location of your configuration file without the need to explicitly include
  the ``-C`` when you write ``yatsm [COMMAND...]`` commands, simplifying
  interactive use.

Options:
  -C, --config PATH      YATSM configuration file [default: ${YATSM_CONFIG}]
  --version              Show the version and exit.
  --num_threads INTEGER  Number of threads for OPENBLAS/MKL/OMP used in NumPy
                         [default: 1]
  -v, --verbose          Increase verbosity.
  -q, --quiet            Decrease verbosity.
  -h, --help             Show this message and exit.

Commands:
  batch      Run a YATSM pipeline on a dataset in batch mode
  changemap  Map change found by YATSM algorithm over time period
  map        Make map of YATSM output for a given date
```

@wkearn this is the short little change I mentioned last Thursday. Lets you do:

``` bash
> yatsm -C examples/HFR1/HFR1_Tower.yaml changemap ...
> export YATSM_CONFIG=examples/HFR1/HFR1_Tower.yaml
# now no need for yatsm -C examples/HFR1/HFR1_Tower.yaml COMMAND
> yatsm changemap ...
```

The changes shouldn't throw too much off but wanted to get into habit of PRs while you're on the ride...